### PR TITLE
Fix #7417

### DIFF
--- a/src/components/menu/menu.ts
+++ b/src/components/menu/menu.ts
@@ -375,9 +375,9 @@ export class Menu implements RootNode, MenuInterface, OnInit, OnDestroy {
     let isEnabled = this._isEnabled;
     if (isEnabled === true || typeof isEnabled === 'undefined') {
       // check if more than one menu is on the same side
-      isEnabled = !this._menuCtrl.getMenus().some(m => {
+      isEnabled = 2 > this._menuCtrl.getMenus().filter(m => {
         return m.side === this.side && m.enabled;
-      });
+      }).length;
     }
     // register this menu with the app's menu controller
     this._menuCtrl._register(this);


### PR DESCRIPTION
#### Short description of what this resolves:
Fixes disappearing menuToggle when hideBackButton is true or swipeBackEnable is false.

#### Changes proposed in this pull request:

- Match the code to the intent described in the comment

**Ionic Version**: 3.x

**Fixes**: #7417

**Details**: 

Use of Array.some() with the given filter function is not achieving the goal stated in the comment, filter returns "true" on self, contradicting the stated purpose. That results in menu getting disabled even in a single menu configuration, while the intent is to find x>1, while Array.some() finds x>=1.

The fix is to either exclude self from consideration (that is a bit convoluted change to either filter function or the Array), or convert ```!Array.some()``` to ```Array.filter().length < 2``` in proposed fix.

Bug in the code was introduced by https://github.com/ionic-team/ionic/commit/ff24152524fabb1aaca0ab7314e2e8ca2bbb7af7

However, the issue seems to be conditional on CSS being applied for "back button" removal, entangling it with hideBackButton and [swipeBackEnabled]="false". Another way to "fix the issue" is remove hideBackButton or [swipeBackEnabled]="false", but it only masks the bug.